### PR TITLE
newsページの追加

### DIFF
--- a/components/News.vue
+++ b/components/News.vue
@@ -1,0 +1,99 @@
+<template>
+    <section class="p-news">
+      <div class="l-container">
+        <div class="p-news__title">news</div>
+        <div class="p-news__intro">
+          <h2 class="p-news__secHeading">新型コロナウィルス感染症に関する対応方針について</h2>
+          <p class="p-news__read">
+            PHPカンファレンス関西は予定通り5月9日（土）に開催することを目指して準備を進めています。<br>
+            ただし、今後の状況により、イベントの自粛などが必要と判断した場合には、不本意ながらイベント自体の延期、または中止を判断する可能性もありますので、予めご了承ください。<br>
+            しかしながら、現時点で5月の開催是非を決定できるための十分な情報がなく、また時間の猶予もあることから、現在は予定通り開催に向けて準備を進めております。<br>
+            運営委員会としては、引き続き状況を注視しつつ、全関係者にとって最善の選択ができるよう、検討と判断をしていきます。
+          </p>
+        </div>
+      </div>
+    </section>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style lang="scss" scoped>
+@import "~/assets/scss/common.scss";
+
+.p-news {
+  margin: 0 auto ;
+  position: relative;
+  color: $clr_accentcolor;
+  background-color: $clr_basecolor;
+  @include desktop {
+    background-image:url("~assets/images/about/about_zou_left.png"),url("~assets/images/about/about_zou_right.png");
+    background-position: bottom 20px left 6%,bottom 20px right 0px;
+    background-repeat: no-repeat;
+  }
+
+  &__title {
+    @include c-section-title;
+
+  }
+
+  &__intro {
+    background-color: #ffffff;
+    border-radius: 10px;
+    font-family: 'M PLUS Rounded 1c', sans-serif;
+    font-weight: bold;
+    @include desktop {
+      border-radius: 0px;
+    }
+    display: inline-block;
+    padding: 30px 20px 36px 20px;
+    width: 100%;
+    text-align: center;
+    margin-bottom: 100px;
+    @include desktop {
+      text-align: center;
+      padding: 50px 80px 90px 80px;
+      font-size: 2.8rem;
+      margin-bottom: 200px;
+    }
+  }
+
+  &__secHeading {
+    display: inline-block;
+    text-align: center;
+    letter-spacing: 1.12px;
+    font-size: 1.6rem;
+    margin-bottom: 20px;
+
+    @include desktop {
+    height: 39px;
+    font-size: 2.8rem;
+    margin-bottom: 45px;
+    margin-top: 25px;
+    }
+
+
+  }
+
+  &__read {
+    display: inline-block;
+    font-family: 'M PLUS Rounded 1c', sans-serif;
+    font-weight: bold;
+    text-align: center;
+    font-size: 1.3rem;
+    line-height: 2;
+    @include desktop {
+    display: inline-block;
+    width: 683px;
+    height: 115px;
+    text-align: center;
+    font-size: 1.8rem;
+    line-height: 2;
+    }
+  }
+}
+
+</style>

--- a/components/top/Hero.vue
+++ b/components/top/Hero.vue
@@ -11,6 +11,12 @@
         5/9
       </date>
       <p class="c-hero__location"><img src="@/assets/images/hero/place-24px.svg" class="c-hero__locationIcon" alt="location-pin" /> ブリーゼプラザ ホール&カンファレンス</p>
+      <div class="c-hero__news">
+        <router-link class="c-hero__text" to="/news">
+          新型コロナウィルス感染症 (2019-nCoV, COVID-19) <br>
+        に関する対応方針について（2020年2月28日時点）
+        </router-link>
+      </div>
       <p class="c-hero__announce">スポンサー、登壇者募集開始！！</p>
       <div class="c-hero__buttons">
         <a href="https://docs.google.com/forms/d/e/1FAIpQLSfyrd-NmeeGTQke-2-KyBqXU2D10Hd7CcJheewBAd1Os6YIOA/viewform" class="c-hero__button" target="_blank" >スポンサー募集中</a>
@@ -150,6 +156,28 @@ $font-family:"M PLUS Rounded 1c";
 
     }
 
+    &__news {
+      padding: 10px 10px 10px 10px;
+      display: inline-block;
+      border: solid 2px $clr_accentcolor;
+      text-align: center;
+      margin-top: 15px;
+      @include desktop {
+        padding: 10px 35px 10px 35px;
+        margin-top: 25px;
+      }
+    }
+
+    &__text {
+      font-size: 1.2rem;
+      font-weight: bold;
+      line-height: 1.2;
+      @include desktop {
+        font-size: 1.6rem;
+        line-height: 1;
+      }
+    }
+
     &__locationIcon {
       text-align: center;
       width: 17px;
@@ -168,12 +196,12 @@ $font-family:"M PLUS Rounded 1c";
       min-width:280px;
       display: inline-block;
       margin: 0 auto;
-      margin-top:30px;
+      margin-top:20px;
       padding: 5px 0px 5px 0px;
       @include desktop {
         width:460px;
         font-size: 23px;
-        margin-top:46px;
+        margin-top: 30px;
       }
     }
 

--- a/components/top/Hero.vue
+++ b/components/top/Hero.vue
@@ -157,13 +157,10 @@ $font-family:"M PLUS Rounded 1c";
     }
 
     &__news {
-      padding: 10px 10px 10px 10px;
       display: inline-block;
-      border: solid 2px $clr_accentcolor;
       text-align: center;
       margin-top: 15px;
       @include desktop {
-        padding: 10px 35px 10px 35px;
         margin-top: 25px;
       }
     }

--- a/components/top/Hero.vue
+++ b/components/top/Hero.vue
@@ -157,7 +157,6 @@ $font-family:"M PLUS Rounded 1c";
     }
 
     &__news {
-      display: inline-block;
       text-align: center;
       margin-top: 15px;
       @include desktop {

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -1,0 +1,60 @@
+<template>
+  <main>
+    <div class="c-background">
+      <Share />
+      <p-news></p-news>
+      <L-footer></L-footer>
+    </div>
+  </main>
+</template>
+
+<script>
+import PNews from '~/components/News.vue'
+import Share from "~/components/top/-Share.vue";
+import LFooter from "~/components/Footer.vue";
+
+export default {
+  components: {
+    PNews,
+    LFooter,
+    Share
+  },
+  head: {
+      title: 'PHPカンファレンス関西2020 は 5月9日(土)に開催!',
+      meta: [
+        { property: 'og:title', content: 'PHPカンファレンス関西2020 は 5月9日(土)に開催!' },
+        { property: 'og:image', content: 'https://2020.kphpug.jp/images/ogp.jpg' },
+        { property: 'og:url', content: 'https://2020.kphpug.jp/' },
+        { property: 'og:description', content: '集え、PHPer！！PHPerのGWはこの日が本番あのPHPの祭典がついに帰ってきた！今回のテーマは「Share!!」当日はPHPに関するトークセッションのほか、懇親会やその他イベントを実施予定「PHPカンファレンス関西」で知識•技術•感動をみんなで分かち合おう！' },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'description', content: '集え、PHPer！！PHPerのGWはこの日が本番あのPHPの祭典がついに帰ってきた！今回のテーマは「Share!!」当日はPHPに関するトークセッションのほか、懇親会やその他イベントを実施予定「PHPカンファレンス関西」で知識•技術•感動をみんなで分かち合おう！' }
+
+      ]
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+
+@import "~/assets/scss/common.scss";
+
+.c-background {
+
+  &:before {
+    content:"";
+    width: 100vw;
+    height: 100vh;
+    background-image: url('~assets/images/hero/hero_sp_zou.png');
+    background-repeat: no-repeat;
+    background-size: 100%;
+    display: block;
+    position: fixed;
+  }
+
+    @include desktop(){
+    &:before {
+      background:none;
+    }
+}
+}
+</style>


### PR DESCRIPTION
コロナウイルスに関する記述を追加しました。

文章量的に、TOPにリンクを置き、別ページ飛ばす形で追加いたしました。

文章
https://www.dropbox.com/scl/fi/4tn5c9zzuxrhinkyrjok7/%E6%96%B0%E5%9E%8B%E3%82%B3%E3%83%AD%E3%83%8A%E3%82%A6%E3%82%A4%E3%83%AB%E3%82%B9_%E3%81%94%E6%A1%88%E5%86%85_%E4%B8%80%E8%88%AC%E5%90%91%E3%81%91.paper?dl=0&rlkey=fjk3wyptplacns0gt0kn83h76